### PR TITLE
Add graphviz to ReadTheDocs dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
It can't draw inheritance diagrams without it.